### PR TITLE
Remove section VIII-3 so that proposed zoning changes do not require …

### DIFF
--- a/CHARTER/ARTICLE 08 - CITY PLANNING COMMISSION.mdown
+++ b/CHARTER/ARTICLE 08 - CITY PLANNING COMMISSION.mdown
@@ -23,12 +23,6 @@ SECTION VIII-2.  MEMBERS, QUALIFICATIONS, AND TERMS.
 The Planning Commission shall consist of the Mayor, the Service Director and three (3) citizen members, holding no other elected public office and shall hold no employment with the City.  Two (2) citizen members shall be appointed by the Mayor and one (1) citizen member shall be appointed by Council, subject to the confirmation of 2/3 vote of all the members elected to Council, and shall serve for a term of five (5) years, however, upon passage of the Charter, the then existing members of the Planning Commission shall remain in office for the terms for which they were appointed.  Any vacancy occurring in the Commission shall be filled for the unexpired portion of the term only and in the manner prescribed by this Charter for the original appointment.  Any appointed citizen member of the Commission may be removed by the Mayor and/or Council for cause, subject to the approval of 2/3 of all the members elected to Council, and upon complaint and a public hearing.  The Commission shall make its own rules and shall appoint a chairman and secretary.  It shall keep a journal of its proceedings and its meetings shall be open to the public at all times.
 (Amended November 2, 2010)
 
-SECTION VIII-3.  MANDATORY REFERRAL.
-------------------------------------
-
-Any change to the existing land uses cannot be approved unless and until it shall have been submitted to the Planning Commission, for approval or disapproval.  In the event the City Council should approve any of the preceding changes, whether approved or disapproved by the Planning Commission it shall not be approved or passed by the declaration of an emergency, and it shall not be effective, but it shall be mandatory that the same be approved by a majority vote of all votes cast of the qualified electors of the City of Eastlake at the next regular Municipal election, if one shall occur not less than sixty (60) or more than one hundred and twenty (120) days after its passage, otherwise at a special election falling on the generally established day of the primary election.  Said issue shall be submitted to the electors of the City only after approval of a change of an existing land use by the Council for an applicant.  Should the land use request not be affirmed by a majority vote it cannot be presented again for one full year and a new request must be made at that time.
-(Amended June 3, 1980)
-
 SECTION VIII-4.  ZONING BOARD OF APPEALS.
 -----------------------------------------
 


### PR DESCRIPTION
…popular ballot vote.

Detailed reasoning for the proposed City Charter amendment here.  Presently, legislative actions affecting land use, e.g., zoning map changes and zoning ordinance amendments, must be referred to the electorate for popular ballot vote.  According to city officials, businesses that would require zoning changes to operate within the city do not wish to spend the resources required to obtain necessary zoning changes.